### PR TITLE
Add OnDatabaseChange to improve readability

### DIFF
--- a/library/src/main/java/nl/nl2312/rxcupboard/OnDatabaseChange.java
+++ b/library/src/main/java/nl/nl2312/rxcupboard/OnDatabaseChange.java
@@ -1,0 +1,23 @@
+package nl.nl2312.rxcupboard;
+
+import rx.functions.Action1;
+
+public abstract class OnDatabaseChange<T> implements Action1<DatabaseChange<T>> {
+
+    public void onUpdate(T entity) {}
+
+    public void onInsert(T entity) {}
+
+    public void onDelete(T entity) {}
+
+    @Override
+    public void call(DatabaseChange<T> databaseChange) {
+        if (databaseChange instanceof DatabaseChange.DatabaseUpdate) {
+            onUpdate(databaseChange.entity());
+        } else if (databaseChange instanceof DatabaseChange.DatabaseInsert) {
+            onInsert(databaseChange.entity());
+        } else if (databaseChange instanceof DatabaseChange.DatabaseDelete) {
+            onDelete(databaseChange.entity());
+        }
+    }
+}

--- a/sample/src/main/java/nl/nl2312/rxcupboard/sample/ui/MainActivity.java
+++ b/sample/src/main/java/nl/nl2312/rxcupboard/sample/ui/MainActivity.java
@@ -11,6 +11,7 @@ import android.widget.Toast;
 import java.util.List;
 
 import nl.nl2312.rxcupboard.DatabaseChange;
+import nl.nl2312.rxcupboard.OnDatabaseChange;
 import nl.nl2312.rxcupboard.RxCupboard;
 import nl.nl2312.rxcupboard.RxDatabase;
 import nl.nl2312.rxcupboard.sample.CupboardDbHelper;
@@ -64,14 +65,15 @@ public class MainActivity extends RxActivity {
 		}, toastErrorAction);
 
 		// Add/remove items to/from the list view on any changes in the Item database table
-		rxBind(rxCupboard.changes(Item.class)).subscribe(new Action1<DatabaseChange<Item>>() {
+		rxBind(rxCupboard.changes(Item.class)).subscribe(new OnDatabaseChange<Item>() {
 			@Override
-			public void call(DatabaseChange<Item> databaseChange) {
-				if (databaseChange instanceof DatabaseChange.DatabaseInsert) {
-					adapter.add(databaseChange.entity());
-				} else if (databaseChange instanceof DatabaseChange.DatabaseDelete) {
-					adapter.remove(databaseChange.entity());
-				}
+			public void onInsert(Item entity) {
+			    	adapter.add(entity);
+			}
+
+			@Override
+			public void onDelete(Item entity) {
+			    	adapter.remove(entity);
 			}
 		}, toastErrorAction);
 


### PR DESCRIPTION
Just my random thought. Not sure if you'd like it.

**I proposed `OnDatabaseChange`**.
So instead of

``` java
    rxBind(rxCupboard.changes(Item.class)).subscribe(new Action1<DatabaseChange<Item>>() {
            @Override
            public void call(DatabaseChange<Item> databaseChange) {
                if (databaseChange instanceof DatabaseChange.DatabaseInsert) {
                    adapter.add(databaseChange.entity());
                } else if (databaseChange instanceof DatabaseChange.DatabaseDelete) {
                    adapter.remove(databaseChange.entity());
                }
            }
        }, toastErrorAction);
```

We can write:

``` java
    rxBind(rxCupboard.changes(Item.class)).subscribe(new OnDatabaseChange<Item>() {
            @Override
            public void onInsert(Item entity) {
            adapter.add(entity);
            }

            @Override
            public void onDelete(Item entity) {
            adapter.remove(entity);
            }
        }, toastErrorAction);
```
